### PR TITLE
feat: DEVOPS-1724 set ping log message to debug mode

### DIFF
--- a/src/socket/socket_mode.rs
+++ b/src/socket/socket_mode.rs
@@ -150,7 +150,7 @@ where
                         }
                     }
                 }
-                Message::Ping(p) => log::info!("ping: {:?}", p),
+                Message::Ping(p) => log::debug!("ping: {:?}", p),
                 Message::Close(_) => {
                     handler.on_close(&self).await;
                     break;


### PR DESCRIPTION
The ping message is useful for debugging purposes but in production mode we do not require constant ping logs that reduce the visibility and increase the storage.

For example:
`[2024-11-15T06:46:02Z INFO  slack_rust::socket::socket_mode] ping: [80, 105, 110, 103, 32, 102, 114, 111, 109, 32, 97, 112, 112, 108, 105, 110, 107, 45, 48]
Generating the alert list ...
[2024-11-15T06:46:12Z INFO  slack_rust::socket::socket_mode] ping: [80, 105, 110, 103, 32, 102, 114, 111, 109, 32, 97, 112, 112, 108, 105, 110, 107, 45, 48]
[2024-11-15T06:46:22Z INFO  slack_rust::socket::socket_mode] ping: [80, 105, 110, 103, 32, 102, 114, 111, 109, 32, 97, 112, 112, 108, 105, 110, 107, 45, 48]
[2024-11-15T06:46:32Z INFO  slack_rust::socket::socket_mode] ping: [80, 105, 110, 103, 32, 102, 114, 111, 109, 32, 97, 112, 112, 108, 105, 110, 107, 45, 48]
[2024-11-15T06:46:42Z INFO  slack_rust::socket::socket_mode] ping: [80, 105, 110, 103, 32, 102, 114, 111, 109, 32, 97, 112, 112, 108, 105, 110, 107, 45, 48]
[2024-11-15T06:46:52Z INFO  slack_rust::socket::socket_mode] ping: [80, 105, 110, 103, 32, 102, 114, 111, 109, 32, 97, 112, 112, 108, 105, 110, 107, 45, 48]`